### PR TITLE
Hashtoolset

### DIFF
--- a/ContentSerializer/ContentFile.cs
+++ b/ContentSerializer/ContentFile.cs
@@ -66,5 +66,17 @@ namespace LeagueSandbox.ContentSerializer
             result.ContentFormatVersion = 4;
             return result;
         }
+
+        public static ContentFile FromInibin(Inibin source, InibinConverter converter)
+        {
+            var result = new ContentFile();
+            result.Values = result.Values = converter.Convert(source);
+            result.Id = 0;
+            result.Name = "";
+            result.ResourcePath = source.FilePath;
+            result.ContentFormatVersion = 2;
+            return result;
+        }
+
     }
 }

--- a/ContentSerializer/ContentSerializer.csproj
+++ b/ContentSerializer/ContentSerializer.csproj
@@ -56,6 +56,8 @@
     <Compile Include="HashForce\HashForcer.cs" />
     <Compile Include="LaunchArguments.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="ProgramInterface.cs" />
+    <Compile Include="ProgramInterfaceCLI.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SelectionFilter.cs" />
   </ItemGroup>

--- a/ContentSerializer/ConversionMap.cs
+++ b/ContentSerializer/ConversionMap.cs
@@ -59,6 +59,32 @@ namespace LeagueSandbox.ContentSerializer
             }
             return result;
         }
+
+        public static ConversionMap FromHashCollection(LeagueHashCollection col)
+        {
+            var result = new ConversionMap();
+            var mapping = new Dictionary<string, Dictionary<string, uint>>();
+            foreach (var entry in col.Hashes)
+            {
+                var hash = entry.Key;
+                var section = entry.Value.First();
+                var name = section.Value.First();
+                if (!mapping.ContainsKey(section.Key)) mapping[section.Key] = new Dictionary<string, uint>();
+                mapping[section.Key].Add(name, hash);
+            }
+
+            foreach (var kvp in mapping)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    var key = new InibinKey(kvp.Key, entry.Key);
+                    var hash = entry.Value;
+                    result.Add(key, hash);
+                }
+            }
+            return result;
+        }
+
     }
 
     public class InibinConverter

--- a/ContentSerializer/HashForce/HashForcer.cs
+++ b/ContentSerializer/HashForce/HashForcer.cs
@@ -128,6 +128,28 @@ namespace LeagueSandbox.ContentSerializer.HashForce
             if (newline) Console.WriteLine(message);
             else Console.Write(message);
         }
+
+        public void SetHashes(HashSet<uint> hset)
+        {
+            _hashes = hset;
+        }
+
+        public void SetSources(List<string> list)
+        {
+            var stringList = new HashSet<string>();
+            foreach (string value in list)
+            {
+                if (string.IsNullOrEmpty(value)) continue;
+                if (stringList.Contains(value)) continue;
+                stringList.Add(value);
+            }
+            _stringSources = stringList.ToArray();
+        }
+
+        public void Clear()
+        {
+            _hashes.Clear();
+        }
     }
 
     public class HashWorker

--- a/ContentSerializer/Program.cs
+++ b/ContentSerializer/Program.cs
@@ -24,6 +24,8 @@ namespace LeagueSandbox.ContentSerializer
 
         static void Main(string[] args)
         {
+            new ProgramInterfaceCLI().ConsoleInterface();
+            return;
             var timer = new Stopwatch();
             timer.Start();
 

--- a/ContentSerializer/ProgramInterface.cs
+++ b/ContentSerializer/ProgramInterface.cs
@@ -542,8 +542,10 @@ namespace LeagueSandbox.ContentSerializer
                 if (!mapping.ContainsKey(section.Key)) mapping[section.Key] = new Dictionary<string, uint>();
                 mapping[section.Key].Add(name, hash);
             }
-            var mappingJson = JsonConvert.SerializeObject(mapping, Formatting.Indented);
-            File.WriteAllText(target, mappingJson);
+
+            var mappingJson = JObject.FromObject(mapping);
+            Program.SanitizeAndSort(mappingJson);
+            File.WriteAllText(target,JsonConvert.SerializeObject(mappingJson, Formatting.Indented));
             return 0;
         }
 

--- a/ContentSerializer/ProgramInterface.cs
+++ b/ContentSerializer/ProgramInterface.cs
@@ -1,0 +1,534 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Diagnostics;
+using System.Collections.Generic;
+using LeagueSandbox.ContentSerializer.HashForce;
+using LeagueLib.Files;
+using LeagueLib.Tools;
+using LeagueLib.Hashes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Xml.Linq;
+using LeagueLib.Files.Manifest;
+using System.Text.RegularExpressions;
+
+namespace LeagueSandbox.ContentSerializer
+{
+    class ProgramInterface
+    {
+        private ArchiveFileManager _manager;
+        private List<ReleaseManifestFileEntry> _files;
+        private LeagueHashCollection _draft;
+        private List<string> _strings;
+        private HashSet<uint> _hashes;
+        private List<string> _paterns;
+
+        
+        public ProgramInterface()
+        {
+            _hashes = new HashSet<uint>();
+            _manager = null;
+            _files = new List<ReleaseManifestFileEntry>();
+            _draft = new LeagueHashCollection();
+            _strings = new List<string>();
+            _paterns = new List<string>();
+        }
+
+
+        public void LoadManager(string path)
+        {
+            _manager = new ArchiveFileManager(path);
+        }
+
+        public void AddPatern(string patern)
+        {
+            if (!_paterns.Contains(patern))
+            {
+                _paterns.Add(patern);
+            }
+            var files = _manager.GetAllFileEntries();
+            foreach (var entry in files)
+            {
+                if (new Regex(patern, RegexOptions.IgnoreCase).Match(entry.FullName).Success)
+                {
+                    _files.Add(entry);
+                    var file = _manager.ReadFile(entry.FullName).Uncompress();
+                    var inibin = Inibin.DeserializeInibin(file, entry.FullName);
+                    foreach (var kvp in inibin.Content)
+                    {
+                        if (!_hashes.Contains(kvp.Key))
+                        {
+                            _hashes.Add(kvp.Key);
+                        }
+                    }
+                }
+            }
+        }
+        
+        public void ListPaterns()
+        {
+            int c = 0;
+            foreach(var patern in _paterns)
+            {
+                Console.WriteLine(c + " - " + patern);
+            }
+        }
+
+        public void RemovePatern(int index)
+        {
+            if (_paterns.Count> index && index > -1)
+            {
+
+            }
+            string patern = _paterns[index];
+            _paterns.Remove(patern);
+            _files.Clear();
+            _hashes.Clear();
+            foreach(string pat in _paterns)
+            {
+                AddPatern(pat);
+            }
+
+        }
+
+        public void ClearFiles()
+        {
+            _paterns.Clear();
+            _files.Clear();
+            _hashes.Clear();
+        }
+
+        public void HashStrings()
+        {
+            var hashForcer = new HashForcer(true);
+            hashForcer.SetHashes(_hashes);
+            hashForcer.SetSources(_strings);
+            hashForcer.Run(Environment.ProcessorCount);
+            hashForcer.WaitFinish();
+            var mapping = new LeagueHashCollection(hashForcer.GetResult());
+
+            var result = new LeagueHashCollection();
+            foreach (var hash in mapping.Hashes)
+            {
+                var sectionFilterer = new SectionFilterer(hash.Value);
+                sectionFilterer.ApplyFilter(new FilterPlaintextSections());
+                sectionFilterer.ApplyFilter(new FilterDuplicateSections());
+                sectionFilterer.ApplyFilter(new FilterPlaintextKeys());
+                result.Hashes.Add(hash.Key, sectionFilterer.CurrentSections);
+            }
+            _draft = result;
+        }
+
+        public int ImportStrings(string path)
+        {
+            if (!File.Exists(path))
+                return 1;
+            var list = JArray.Parse(File.ReadAllText(path));
+            foreach (string item in list)
+            {
+                if (!_strings.Contains(item, StringComparer.OrdinalIgnoreCase))
+                {
+                    _strings.Add(item);
+                }
+            }
+            return 0;
+        }
+        
+        public int ImportDraftStrings(string input)
+        {
+            if (!File.Exists(input))
+                return 1;
+            var data = File.ReadAllText(input);
+            var draft = JsonConvert.DeserializeObject<LeagueHashCollection>(data);
+            ImportDraftStrings(draft);
+            return 0;
+        }
+
+        public void ImportDraftStrings(LeagueHashCollection col)
+        {
+            foreach (var hash in col.Hashes)
+            {
+                foreach (var section in hash.Value)
+                {
+                    if (!_strings.Contains(section.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        _strings.Add(section.Key);
+                    }
+                    foreach (var name in section.Value)
+                    {
+
+                        if (!_strings.Contains(name, StringComparer.OrdinalIgnoreCase))
+                        {
+                            _strings.Add(name);
+                        }
+                    }
+                }
+            }
+        }
+
+        public void SyncStrings()
+        {
+            ImportDraftStrings(_draft);
+        }
+
+        public void ClearStrings()
+        {
+            _strings.Clear();
+        }
+
+
+
+        public void ExportDraft(string output)
+        {
+            var data = JsonConvert.SerializeObject(_draft, Formatting.Indented);
+            File.WriteAllText(output, data);
+        }
+
+        public void ExportStrings(string output)
+        {
+            File.WriteAllText(output, JsonConvert.SerializeObject(_strings, Formatting.Indented));
+        }
+
+        public void ExportData(string directory)
+        {
+            Directory.CreateDirectory(directory);
+            var converter = new InibinConverter(ConversionMap.FromHashCollection(_draft));
+
+            foreach (var file in _files)
+            {
+                var inibin = _manager.ReadInibin(file.FullName);
+                var item = ContentFile.FromInibin(inibin, converter);
+                var orgPath = Path.GetDirectoryName(file.FullName);
+                var orgName = Path.GetFileNameWithoutExtension(file.FullName);
+                Directory.CreateDirectory(directory+"/"+orgPath);
+                var savePath = directory + "/" + orgPath + "/" + orgName + ".json";
+                File.WriteAllText(savePath, item.Serialize());
+            }
+        }
+
+        public int CountStrings()
+        {
+            return _strings.Count;
+        }
+        
+        public int CountHashes()
+        {
+            return _hashes.Count;
+        }
+
+        public int CountDraftHashes()
+        {
+            return _draft.Hashes.Count;
+        }
+
+        public int CountDraftSections()
+        {
+            int s = 0;
+            foreach(var hash in _draft.Hashes)
+            {
+                s += hash.Value.Count;
+            }
+            return s;
+        }
+
+        public int CountDraftNames()
+        {
+            int s = 0;
+            foreach (var hash in _draft.Hashes)
+            {
+                foreach(var section in hash.Value)
+                {
+                    s += section.Value.Count;
+                }
+            }
+            return s;
+        }
+
+        public int CountMatches()
+        {
+            int m = 0;
+            foreach (var hash in _draft.Hashes)
+            {
+                if (_hashes.Contains(hash.Key))
+                    m++;
+            }
+            return m;
+        }
+
+        public int CountFiles()
+        {
+            return _files.Count;
+        }
+
+        public int TestHash(string section, string name)
+        {
+            Console.WriteLine("Testing: " + section + "*" + name);
+            var hash = HashFunctions.GetInibinHash(section, name);
+            if (_hashes.Contains(hash))
+            {
+                if (_draft.Hashes.ContainsKey(hash))
+                {
+                    if (_draft.Hashes[hash].Keys.ToList().Contains(section, StringComparer.OrdinalIgnoreCase))
+                    {
+                        if (_draft.Hashes[hash][section].Contains(name, StringComparer.OrdinalIgnoreCase))
+                        {
+                            return 3;
+                        }
+                    }
+                    return 2;
+                }
+                return 1;
+            }
+            return 0;
+        }
+
+        public void AddHash(string section, string name)
+        {
+            _draft.AddFromSource(section, name);
+            AddString(name);
+            AddString(section);
+        }
+
+        public void AddString(string name)
+        {
+            if (!_strings.Contains(name, StringComparer.OrdinalIgnoreCase))
+            {
+                _strings.Add(name);
+            }
+        }
+
+        public int TestAddHash(string section, string name, bool noConflicts)
+        {
+            var res = TestHash(section, name);
+            switch (res)
+            {
+                case 0:
+                    Console.WriteLine("Not found!");
+                    break;
+                case 1:
+                    Console.WriteLine("Found & added!");
+                    AddHash(section, name);
+                    break;
+                case 2:
+                    if (noConflicts)
+                    {
+                        Console.WriteLine("Conflict - only srings added!");
+                        AddString(name);
+                        AddString(section);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Conflict & added!");
+                        AddHash(section, name);
+                    }
+                    break;
+                case 3:
+                    Console.WriteLine("Already present!");
+                    break;
+            }
+            return res;
+        }
+
+        public void PrintFiles()
+        {
+            foreach(var file in _files)
+            {
+                Console.WriteLine(file.FullName);
+            }
+            Console.WriteLine("Total: " + _files.Count);
+        }
+
+        public int ImportMapAsString(string path)
+        {
+            if (!File.Exists(path))
+                return 1;
+            var data = File.ReadAllText(path);
+            var map = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, uint>>>(data);
+            
+            foreach(var section in map)
+            {
+                AddString(section.Key);
+                foreach(var name in section.Value)
+                {
+                    AddString(name.Key);
+                }
+            }
+            return 0;
+        }
+
+        public int ImportMapAsDraft(string path)
+        {
+            if (!File.Exists(path))
+                return 1;
+            var map = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, uint>>>(File.ReadAllText(path));
+
+            foreach (var section in map)
+            {
+                foreach (var name in section.Value)
+                {
+                    _draft.AddFromSource(section.Key, name.Key);      
+                }
+            }
+            return 0;
+        }
+
+        public int ImportDraft(string path)
+        {
+            if (!File.Exists(path))
+                return 1;
+            var data = File.ReadAllText(path);
+            var map = JsonConvert.DeserializeObject<LeagueHashCollection>(data);
+
+            foreach(var hash in map.Hashes)
+            {
+                foreach(var section in hash.Value) {
+                    
+                    foreach(var name in section.Value)
+                    {
+                        _draft.AddFromSource(section.Key, name);
+                    }
+                }
+            }
+            return 0;
+        }
+
+        public void ClearDraft()
+        {
+            _draft.Hashes.Clear();
+        }
+
+        public void PrintConflict()
+        {
+            int c = 0;
+            foreach(var hash in _draft.Hashes)
+            {
+               
+                if (hash.Value.Count > 1)
+                {
+                    Console.WriteLine("Conflict in hash: " + hash.Key);
+                    c++;
+                }
+                else
+                {
+                    foreach (var section in hash.Value)
+                    {
+                        if (section.Value.Count > 1)
+                        {
+                            c++;
+                            Console.WriteLine("Conflict in hash: " + hash.Key);
+                            break;
+                        }
+                    }
+                }
+            }
+            Console.WriteLine("Conflicts: " + c);
+        }
+
+        public void DraftMatch()
+        {
+            var map = new LeagueHashCollection();
+            Console.WriteLine("Starting count: " +_draft.Hashes.Count);
+            foreach(var hash in _draft.Hashes)
+            {
+                if (_hashes.Contains(hash.Key))
+                {
+                    map.Hashes.Add(hash.Key, hash.Value);
+                }
+            }
+            Console.WriteLine("End count: " + map.Hashes.Count);
+            _draft = map;
+        }
+
+        public void UnduplicateDraft()
+        {
+            var map = new LeagueHashCollection();
+            foreach (var hash in _draft.Hashes)
+            {
+                var section2 = new Dictionary<string, HashSet<string>>();
+                foreach (var section in hash.Value)
+                {
+                    if (!section2.Keys.ToList().Contains(section.Key,StringComparer.OrdinalIgnoreCase))
+                    {
+                        var names = new HashSet<string>();
+                        var names2 = new List<string>();
+                        foreach(var name in section.Value)
+                        {
+                            if (!names2.Contains(name, StringComparer.OrdinalIgnoreCase))
+                            {
+                                names.Add(name);
+                                names2.Add(name);
+                            }
+                        }
+                        section2.Add(section.Key, names);
+                    }
+                }
+                map.Hashes.Add(hash.Key, section2);
+            }
+            _draft = map;
+        }
+
+
+        public string ReplaceFirst(string text, string search, string replace)
+        {
+            int pos = text.IndexOf(search);
+            if (pos < 0)
+            {
+                return text;
+            }
+            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
+        }
+         
+        public List<string> FillRange(string str,int from, int to)
+        {
+            List<string> result = new List<string>();
+            var count = Regex.Matches(str, "%d").Count;
+            if(count == 0)
+            {
+                result.Add(str);
+                return result;
+            }else{
+                for(int i = from; i < to; i++)
+                {
+                    result.Add(ReplaceFirst(str, "%d", i.ToString()));
+                }
+                return FillRange(result, from, to);
+            }
+        }
+
+        public List<string> FillRange(List<string> strs, int from,int to)
+        {
+            List<string> result = new List<string>();
+            foreach (string str in strs)
+            {
+                var r = FillRange(str, from, to);
+                result.AddRange(r);
+            }
+            return result;
+        }
+
+        
+        public void RangeTest(string section, string name, int from, int to,bool noconflicts)
+        {
+            List<string> sections = FillRange(section, from, to);
+            List<string> names = FillRange(name, from, to);
+            int[] rs = { 0,0,0,0};
+            int c = 0;
+
+            foreach(var s in sections)
+            {
+                foreach(var n in names)
+                {
+                    rs[TestAddHash(s, n, noconflicts)]++;
+                    c++;
+                }
+            }
+            Console.WriteLine("Not found: " + rs[0]);
+            Console.WriteLine("Found & added: " + rs[1]);
+            Console.WriteLine("Conflict: " + rs[2]);
+            Console.WriteLine("Already present: " + rs[3]);
+            Console.WriteLine("Total: " + c);
+        }
+
+    }
+}

--- a/ContentSerializer/ProgramInterface.cs
+++ b/ContentSerializer/ProgramInterface.cs
@@ -530,5 +530,45 @@ namespace LeagueSandbox.ContentSerializer
             Console.WriteLine("Total: " + c);
         }
 
+        public int ExportToMap(string target)
+        {
+            var mapping = new Dictionary<string, Dictionary<string, uint>>();
+            foreach (var entry in _draft.Hashes)
+            {
+                var hash = entry.Key;
+                var section = entry.Value.First();
+                var name = section.Value.First();
+
+                if (!mapping.ContainsKey(section.Key)) mapping[section.Key] = new Dictionary<string, uint>();
+                mapping[section.Key].Add(name, hash);
+            }
+            var mappingJson = JsonConvert.SerializeObject(mapping, Formatting.Indented);
+            File.WriteAllText(target, mappingJson);
+            return 0;
+        }
+
+        public int ComparetToMap(string target, string output)
+        {
+            if (!File.Exists(target))
+                return -3;
+
+            var data = File.ReadAllText(target);
+            var nmap = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, uint>>>(data);
+
+            var mapping = new Dictionary<string, Dictionary<string, uint>>();
+            foreach (var entry in _draft.Hashes)
+            {
+                var hash = entry.Key;
+                var section = entry.Value.First();
+                var name = section.Value.First();
+
+                if (!mapping.ContainsKey(section.Key)) mapping[section.Key] = new Dictionary<string, uint>();
+                mapping[section.Key].Add(name, hash);
+            }
+            return 0;
+
+        }
+
+
     }
 }

--- a/ContentSerializer/ProgramInterfaceCLI.cs
+++ b/ContentSerializer/ProgramInterfaceCLI.cs
@@ -19,6 +19,8 @@ namespace LeagueSandbox.ContentSerializer
         private static Dictionary<string, string> paterns = new Dictionary<string, string>
         {
             {"items", @"Data\/Items\/([^\/]+)\.inibin"},
+            {"itemgroups", @"Data\/Items\/ItemGroups\/([^\/]+)\.inibin"},
+            {"itemmetadata", @"Data[\/\\]Items[\/\\]metadata[\/\\](.*).inibin"},
             {"spells", @"Data(|\/Characters\/([^\/]+)|\/Shared)\/Spells\/([^\/]+)\.inibin"},
             {"characters", @"Data\/Characters\/([^\/]+)(\/\1\.inibin)"},
             {"talents", @"Data\/Talents\/([^\/]+)\.inibin"},
@@ -140,6 +142,9 @@ namespace LeagueSandbox.ContentSerializer
                 case "importdraft":
                     if (len != 2) return -1;
                     return prog.ImportDraft(cmd[1]);
+                case "exportmap":
+                    if (len != 2) return -1;
+                    return prog.ExportToMap(cmd[1]);
                 case "cleardraft":
                     if (len != 1) return -1;
                     prog.ClearDraft();
@@ -199,6 +204,7 @@ namespace LeagueSandbox.ContentSerializer
                     Console.WriteLine("importdraft [file] - Adds draft");
                     Console.WriteLine("importmapdraft [file] - Adds draft from conversion map");
                     Console.WriteLine("exportdraft [file] - Save draft file");
+                    Console.WriteLine("exportmap [file] - Export Conversion map");
                     Console.WriteLine("cleardraft - Clears draft");
                     Console.WriteLine("-------Draft Manual:");
                     Console.WriteLine("test [name] [section] - Test for hash and add it to draft/strings");

--- a/ContentSerializer/ProgramInterfaceCLI.cs
+++ b/ContentSerializer/ProgramInterfaceCLI.cs
@@ -1,0 +1,287 @@
+﻿using LeagueLib.Files;
+using LeagueLib.Tools;
+using LeagueLib.Hashes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Xml.Linq;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System;
+using System.IO;
+
+namespace LeagueSandbox.ContentSerializer
+{
+    class ProgramInterfaceCLI
+    {
+        
+
+        private static ProgramInterface prog = new ProgramInterface();
+        private static Dictionary<string, string> paterns = new Dictionary<string, string>
+        {
+            {"items", @"Data\/Items\/([^\/]+)\.inibin"},
+            {"spells", @"Data(|\/Characters\/([^\/]+)|\/Shared)\/Spells\/([^\/]+)\.inibin"},
+            {"characters", @"Data\/Characters\/([^\/]+)(\/\1\.inibin)"},
+            {"talents", @"Data\/Talents\/([^\/]+)\.inibin"},
+            {"skins", @"Data\/Characters\/([^\/]+)\/Skins\/([^\/]+)\/\2\.inibin"},
+            {"all", @"(.*)\.inibin"}
+        };
+
+        public ProgramInterfaceCLI()
+        {
+
+        }
+
+        public void ConsoleInterface()
+        {
+            Command("setrads");
+            while (true)
+            {
+                Console.Write("Command: ");
+                switch (Command(Console.ReadLine()))
+                {
+                    case 1:
+                        Console.WriteLine("Command error!");
+                        break;
+                    case -1:
+                        Console.WriteLine("Invalid argument count!");
+                        break;
+                    case -2:
+                        Console.WriteLine("Invalid command");
+                        break;
+                    case -3:
+                        return;
+                }
+            }
+        }
+
+        public int Command(string cmds)
+        {
+            return Command(cmds.Split(' '));
+        }
+
+        public int Command(string[] cmd)
+        {
+            int len = cmd.Length;
+            if (len == 0)
+                return 0;
+            switch (cmd[0])
+            {
+                case "exit":
+                case "quit":
+                case "close":
+                    return -3;
+                case "setrads":
+                    if (len > 2) return -1;
+                    prog.LoadManager(GetPath(len == 2 ? cmd[1] : ""));
+                    break;
+                case "importstrings":
+                    if (len != 2) return -1;
+                    return prog.ImportStrings(cmd[1]);
+                case "addpatern":
+                    if (len != 2) return -1;
+                    SelectPatern(cmd[1]);
+                    break;
+                case "addregex":
+                    if (len != 2) return -1;
+                    if (IsValidRegex(cmd[1]))
+                    {
+                        prog.AddPatern(cmd[1]);
+                    }
+                    break;
+                case "exportdraft":
+                    if (len != 2) return -1;
+                    prog.ExportDraft(cmd[1]);
+                    break;
+                case "exportdata":
+                    if (len != 2) return -1;
+                    prog.ExportData(cmd[1]);
+                    break;
+                case "exportstrings":
+                    if (len != 2) return -1;
+                    prog.ExportStrings(cmd[1]);
+                    break;
+                case "hash":
+                    if (len != 1) return -1;
+                    prog.HashStrings();
+                    break;
+                case "clearstrings":
+                    if (len != 1) return -1;
+                    prog.ClearStrings();
+                    break;
+                case "syncstrings":
+                    if (len != 1) return -1;
+                    prog.SyncStrings();
+                    break;
+                case "importdraftstrings":
+                    if (len != 2) return -1;
+                    return prog.ImportDraftStrings(cmd[1]);
+                case "count":
+                    if (len > 2) return -1;
+                    CountStuff(len == 2 ? cmd[1] : "all");
+                    break;
+                case "test":
+                    if (len != 3) return -1;
+                    prog.TestAddHash(cmd[1], cmd[2], false);
+                    break;
+                case "ctest":
+                    if (len != 3) return -1;
+                    prog.TestAddHash(cmd[1], cmd[2], true);
+                    break;
+                case "listfiles":
+                    if (len != 1) return -1;
+                    prog.PrintFiles();
+                    break;
+                case "importmapstrings":
+                    if (len != 2) return -1;
+                    return prog.ImportMapAsString(cmd[1]);
+                case "importmapdraft":
+                    if (len != 2) return -1;
+                    return prog.ImportMapAsDraft(cmd[1]);
+                case "importdraft":
+                    if (len != 2) return -1;
+                    return prog.ImportDraft(cmd[1]);
+                case "cleardraft":
+                    if (len != 1) return -1;
+                    prog.ClearDraft();
+                    break;
+                case "conflict":
+                    if (len != 1) return -1;
+                    prog.PrintConflict();
+                    break;
+                case "draftmatch":
+                    if (len != 1) return -1;
+                    prog.DraftMatch();
+                    break;
+                case "unduplicatedraft":
+                    if (len != 1) return -1;
+                    prog.UnduplicateDraft();
+                    break;
+                case "clearfiles":
+                    if (len != 1) return -1;
+                    prog.ClearFiles();
+                    break;
+                case "listpaterns":
+                    if (len != 1) return -1;
+                    prog.ListPaterns();
+                    break;
+                case "delpatern":
+                    if (len != 2) return -1;
+                    prog.RemovePatern(int.Parse(cmd[1]));
+                    break;
+                case "rtest":
+                    if (len != 5) return -1;
+                    prog.RangeTest(cmd[1], cmd[2], Int32.Parse(cmd[3]), Int32.Parse(cmd[4]), false);
+                    break;
+                case "help":
+                    Console.WriteLine("Command/Altcommand [argument] [*optional] - descirpiton: ");
+                    Console.WriteLine("---------------------------------------------------------");
+                    Console.WriteLine("-------Misc:");
+                    Console.WriteLine("setrads [*directory] - Set rads path");
+                    Console.WriteLine("exit/quit/close - Exits CLI");
+                    Console.WriteLine("count [*all|strings,hashes,draft,files] - Counts stuff (default all)");
+                    Console.WriteLine("-------Files:");
+                    Console.WriteLine("addpatern [patern] - Set inibin match patern");
+                    Console.WriteLine("addregex [regex] - Set inibin match regex");
+                    Console.WriteLine("listfiles - Prints loaded file list");
+                    Console.WriteLine("listpaterns - Prints paterns index list");
+                    Console.WriteLine("delpatern [index] - Removes patern at index");
+                    Console.WriteLine("clearfiles - Clears files, hashes & paterns");
+                    Console.WriteLine("exportdata [directory] - Export data");
+                    Console.WriteLine("-------Strings:");
+                    Console.WriteLine("importstrings [file] - Adds string list");
+                    Console.WriteLine("importdraftstrings [file] - Import strings from given draft file");
+                    Console.WriteLine("importmapstrings [file] - Adds strings from conversion map");
+                    Console.WriteLine("exportstring [file] - Exports strings");
+                    Console.WriteLine("clearstrings - Clears string list");
+                    Console.WriteLine("syncstrings - Syncs strings to current draft");
+                    Console.WriteLine("-------Draft:");
+                    Console.WriteLine("hash - Hashes strings to draft");
+                    Console.WriteLine("importdraft [file] - Adds draft");
+                    Console.WriteLine("importmapdraft [file] - Adds draft from conversion map");
+                    Console.WriteLine("exportdraft [file] - Save draft file");
+                    Console.WriteLine("cleardraft - Clears draft");
+                    Console.WriteLine("-------Draft Manual:");
+                    Console.WriteLine("test [name] [section] - Test for hash and add it to draft/strings");
+                    Console.WriteLine("ctest [name] [section] - Same as Test but avoids conflicts");
+                    Console.WriteLine("rtest [name] [section] [from] [to] - Brute force %d fromated string in given range(multiple supported)");
+                    Console.WriteLine("conflict - Prints conflicts");
+                    Console.WriteLine("draftmatch - Leaves only hashes that match");
+                    Console.WriteLine("unduplicatedraft - Leaves only non duplciate strings");
+                    Console.WriteLine("---------------------------------------------------------");
+                    break;
+                default:
+                    return -2;
+            }
+            return 0;
+        }
+
+        private string GetPath(string path)
+        {
+            if (path != "") return path;
+            if (File.Exists("rads-path.txt")) return File.ReadAllText("rads-path.txt");
+            Console.WriteLine("Enter rads path: ");
+            return Console.ReadLine();
+        }
+
+        private void SelectPatern(string patern)
+        {
+
+            if (patern == "" || patern == "help" || patern == "list")
+            {
+                Console.Write("Patern names: ");
+                Console.WriteLine(string.Join(", ", paterns.Keys));
+                Console.Write("Regex or name: ");
+                patern = Console.ReadLine();
+            }
+            else if (paterns.ContainsKey(patern))
+            {
+                prog.AddPatern(paterns[patern]);
+            }
+            else
+            {
+                Console.WriteLine("Invalid patern!");
+            }
+        }
+
+        private void CountStuff(string what)
+        {
+            if (what == "" || what == "all")
+                what = "strings,hashes,draft,files";
+
+            if (what.Contains("strings"))
+                Console.WriteLine("Strings: " + prog.CountStrings());
+
+            if (what.Contains("hashes"))
+                Console.WriteLine("Inibin hashes: " + prog.CountHashes());
+
+            if (what.Contains("files"))
+                Console.WriteLine("Files: " + prog.CountFiles());
+
+            if (what.Contains("draft"))
+            {
+                Console.WriteLine("Draft hashes: " + prog.CountDraftHashes());
+                Console.WriteLine("Draft sections: " + prog.CountDraftSections());
+                Console.WriteLine("Draft names: " + prog.CountDraftNames());
+                Console.WriteLine("Matching hashes: " + prog.CountMatches());
+            }
+
+        }
+
+        private  bool IsValidRegex(string pattern)
+        {
+            if (string.IsNullOrEmpty(pattern)) return false;
+
+            try
+            {
+                Regex.Match("", pattern);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
A patched up command line interface to manage/merge/split/sort/compare hashes/drafts/strings together with matching regex patterns.

Moved to separate class (use when needed).
